### PR TITLE
add json file upload and display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "arc-web-view",
-  "version": "1.0.0",
+  "name": "@nfdi4plants/arc-web-view",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "arc-web-view",
-      "version": "1.0.0",
+      "name": "@nfdi4plants/arc-web-view",
+      "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "@nfdi4plants/arctrl": "^3.0.0-beta.3",
         "@primer/css": "^22.0.2",
@@ -14,8 +15,6 @@
         "@primer/react": "^37.29.0",
         "marked": "^16.1.1",
         "mermaid": "^11.9.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
         "styled-components": "^5.3.11"
       },
       "devDependencies": {
@@ -32,6 +31,10 @@
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4",
         "vite-plugin-dts": "^4.5.4"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6298,6 +6301,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6316,6 +6320,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6593,7 +6598,8 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import WebViewer from './components/WebViewer';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import {Banner, Blankslate} from '@primer/react/experimental'
 import Icons from './components/Icons';
 import { FileCacheProvider, SearchCacheProvider } from './ContextProvider';
 import { marked } from 'marked';
-
+import { Flash, Button } from "@primer/react";
+import { UploadIcon, XIcon } from "@primer/octicons-react";
 
 
 function ErrorBanner({error}: {error: string}) {
@@ -50,11 +51,86 @@ interface AppProps {
   licensefetch?: () => Promise<string>;
 }
 
+function UploadJsonButton({ onUpload }: { onUpload: (text: string) => void }) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleClick = () => fileInputRef.current?.click();
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      const text = e.target?.result;
+      if (typeof text === "string") {
+        onUpload(text);
+      }
+    };
+
+    reader.readAsText(file);
+  };
+
+  return (
+    <>
+      <Button
+        leadingVisual={UploadIcon}
+        onClick={handleClick}
+        variant="primary"
+      >
+        Upload ARC RO-Crate JSON
+      </Button>
+
+      {/* Hidden file input */}
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept="application/json"
+        onChange={handleFileChange}
+        style={{ display: "none" }}
+      />
+    </>
+  );
+}
+
 function App({ jsonString: outerJson, readmefetch, licensefetch }: AppProps) {
 
   const [jsonString, setJsonString] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [flashMessage, setFlashMessage] = useState<string | null>(null);
+  const [flashType, setFlashType] = useState<"success" | "danger">("success");
+
+  const [isUploaded, setIsUploaded] = useState(false);
+
+  const handleUploadedJson = (text: string) => {
+    try {
+      JSON.parse(text); // "validate" JSON, replace with an arctrl function later
+      setJsonString(text);
+      setError(null);
+
+      setFlashMessage("JSON file uploaded successfully.");
+      setFlashType("success");
+
+      setIsUploaded(true); // mark that this JSON came from upload
+    } catch {
+      setFlashMessage("The file does not contain valid JSON.");
+      setFlashType("danger");
+    }
+  };
+
+  // remove the flash message after 4 seconds, maybe fading it would be nicer in the future
+  useEffect(() => {
+    if (!flashMessage) return;
+
+    const timer = setTimeout(() => {
+      setFlashMessage(null);
+    }, 4000); // auto-close after 4 seconds
+
+    return () => clearTimeout(timer);
+  }, [flashMessage]);
 
   useEffect(() => {
     const fetchJson = async () => {
@@ -92,13 +168,38 @@ function App({ jsonString: outerJson, readmefetch, licensefetch }: AppProps) {
   return (
     <FileCacheProvider>
       <SearchCacheProvider>
+
+        {flashMessage && (
+          <div style={{ position: "relative", marginBottom: "1rem" }}>
+            <Flash variant={flashType}>
+              {flashMessage}
+              <Button
+                style={{ position: "absolute", right: "0.5rem", top: "0.5rem" }}
+                onClick={() => setFlashMessage(null)}
+                size="small"
+                variant="invisible"
+                leadingVisual={XIcon}
+                aria-label="Close flash message"
+              />
+            </Flash>
+          </div>
+        )}
+
+        <div style={{ padding: "1rem" }}>
+          <UploadJsonButton onUpload={handleUploadedJson} />
+        </div>
+
         {
           error && <ErrorBanner error={error} />
         }
         {
           loading || !jsonString 
             ? <BlankSlate /> 
-            : <WebViewer jsonString={jsonString} readmefetch={readmefetch} licensefetch={licensefetch} />
+            : <WebViewer 
+                jsonString={jsonString} 
+                readmefetch={isUploaded ? undefined : readmefetch} 
+                licensefetch={isUploaded ? undefined : licensefetch} 
+              />
         }
       </SearchCacheProvider>
     </FileCacheProvider>


### PR DESCRIPTION
I think having a simple button to upload an ro crate and display it on the site (gh pages, NOT the component!) is very helpful for any situtations where you'd want a simple ro crate perview. 

I think we should also put this page directly on nfdi4plants.org (arc-viewer.nfdi4plants.org? @j-bauer @Freymaurer )