### PR TITLE
Implement a View of the Process Graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@dagrejs/dagre": "^1.1.8",
         "@nfdi4plants/arctrl": "^3.0.0-beta.3",
         "@primer/css": "^22.0.2",
         "@primer/primitives": "^11.0.0",
@@ -420,6 +421,24 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.8.tgz",
+      "integrity": "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.2.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
+      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">17.0.0"
+      }
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
-  "name": "arc-web-view",
+  "name": "@nfdi4plants/arc-web-view",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "arc-web-view",
+      "name": "@nfdi4plants/arc-web-view",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@nfdi4plants/arctrl": "^3.0.0-beta.3",
         "@primer/css": "^22.0.2",
         "@primer/primitives": "^11.0.0",
         "@primer/react": "^37.29.0",
+        "graphology": "^0.26.0",
         "marked": "^16.1.1",
         "mermaid": "^11.9.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "sigma": "^3.0.2",
         "styled-components": "^5.3.11"
       },
       "devDependencies": {
@@ -32,6 +33,10 @@
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4",
         "vite-plugin-dts": "^4.5.4"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -97,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1541,7 +1547,8 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.0.0.tgz",
       "integrity": "sha512-GREFF8jTAyfs8lMhLQLAtuqmd9LJqodfI1ejmUSL3IEWtoATRSQAy8eqksjV/LcJnJoKNft42hyAeAbawskpaw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@primer/react": {
       "version": "37.29.0",
@@ -1956,6 +1963,7 @@
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -2552,18 +2560,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2576,6 +2572,7 @@
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2586,6 +2583,7 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2686,6 +2684,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -3060,6 +3059,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3374,6 +3374,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3510,6 +3511,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -3708,6 +3710,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.1.tgz",
       "integrity": "sha512-dbeqFTLYEwlFg7UGtcZhCCG/2WayX72zK3Sq323CEX29CY81tYfVhw1MIdduCtpstB0cTOhJswWlM/OEB3Xp+Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4108,6 +4111,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4423,6 +4427,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4600,6 +4605,15 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/exsolve": {
@@ -5005,6 +5019,34 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/graphology": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
+      }
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -6298,6 +6340,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6316,6 +6359,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6342,7 +6386,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6639,6 +6684,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/sigma": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.2.tgz",
+      "integrity": "sha512-/BUbeOwPGruiBOm0YQQ6ZMcLIZ6tf/W+Jcm7dxZyAX0tK3WP9/sq7/NAWBxPIxVahdGjCJoGwej0Gdrv0DxlQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "graphology-utils": "^2.5.2"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6736,6 +6791,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -6895,6 +6951,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7002,6 +7059,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7039,15 +7097,6 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
-    },
-    "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -7168,6 +7217,7 @@
       "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -7285,6 +7335,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
       "styles": "./dist/arc-web-view.css"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
@@ -52,8 +54,10 @@
     "@primer/css": "^22.0.2",
     "@primer/primitives": "^11.0.0",
     "@primer/react": "^37.29.0",
+    "graphology": "^0.26.0",
     "marked": "^16.1.1",
     "mermaid": "^11.9.0",
+    "sigma": "^3.0.2",
     "styled-components": "^5.3.11"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "build:lib": "tsc -b && vite build --config vite.config.lib.ts"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.8",
     "@nfdi4plants/arctrl": "^3.0.0-beta.3",
     "@primer/css": "^22.0.2",
     "@primer/primitives": "^11.0.0",

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -17,6 +17,7 @@ const containerStyle: React.CSSProperties = {
 type Node = {
   id: string;
   label: string;
+  type: string;
   x?: number;
   y?: number;
 };
@@ -67,10 +68,10 @@ function nodesAndEdgesFromProcesses(processes: LDNode[], ldGraph: LDGraph, conte
 
       // Only add unique nodes
       if (!nodes.some(n => n.id === input.id)) {
-        nodes.push({ id: input.id, label: input.id });
+        nodes.push({ id: input.id, label: input.id, type: input.AdditionalType[0] || input.SchemaType[0] });
       }
       if (!nodes.some(n => n.id === output.id)) {
-        nodes.push({ id: output.id, label: output.id });
+        nodes.push({ id: output.id, label: output.id, type: output.AdditionalType[0] || output.SchemaType[0] });
       }
     }
   });
@@ -113,7 +114,27 @@ function buildSigmaGraph(graph: LDGraph) {
 
   const sigmaGraph = new Graph();
   nodes.forEach((node) => {
-    sigmaGraph.addNode(node.id, { x: node.x, y: node.y, label: node.label })
+    let color: string;
+    let size: number;
+    switch (node.type) {
+      case "Source":
+        color = "#3B734E";
+        size = 4;
+        break;
+      case "Sample":
+        color = "#2E68D3";
+        size = 3;
+        break;
+      case "File":
+        color = "#202328";
+        size = 2;
+        break;
+      default:
+        color = "black";
+        size = 2;
+        break;
+    }
+    sigmaGraph.addNode(node.id, { x: node.x, y: node.y, label: node.label, color, size })
   })
   edges.forEach((edge) => {
     sigmaGraph.addDirectedEdge(edge.source, edge.target, { label: edge.label })

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -14,6 +14,8 @@ const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const graphViewRef = useRef<GraphView | null>(null);
 
+  window.ldGraph = graph;
+
   useEffect(() => {
     if (containerRef.current) {
       graphViewRef.current = new GraphView(graph, containerRef.current);

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef } from "react";
+import { ROCrate } from '@nfdi4plants/arctrl'
 import Sigma from "sigma";
 import Graph from "graphology";
+import dagre from "@dagrejs/dagre";
 
 const containerStyle: React.CSSProperties = {
   width: "800px",
@@ -8,20 +10,61 @@ const containerStyle: React.CSSProperties = {
   background: "white",
 };
 
-const GraphViewer: React.FC = () => {
+function getAllProcesses(graph: any) {
+  const processes = graph.Nodes.filter(
+    node => ROCrate.LDLabProcess.validate(node, graph.TryGetContext())
+  );
+  return processes;
+}
+
+function addNodesFromProcesses(processes: any, graph: any, sigmaGraph: Graph) {
+  let dg = new dagre.graphlib.Graph()
+
+  dg.setGraph({ rankdir: 'LR' })
+  // Default to assigning a new object as a label for each new edge.
+  dg.setDefaultEdgeLabel(function() { return {}; });
+  processes.forEach((process) => {
+    let input = ROCrate.LDLabProcess.getObjects(process, graph, graph.TryGetContext())[0].id
+    let output = ROCrate.LDLabProcess.getResults(process, graph, graph.TryGetContext())[0].id
+    if (!dg.hasNode(input))
+      dg.setNode(input, { label: input,  width: 144, height: 100 });
+    //sigmaGraph.addNode(input, { x: Math.random(), y:Math.random(), label: input})
+    if (!dg.hasNode(output))
+      dg.setNode(output, { label: output,  width: 144, height: 100 });
+    dg.setEdge(input, output)
+  })
+  dagre.layout(dg)
+  console.log(dg)
+  window.dg = dg;
+  dg.nodes().forEach((n) => {
+    sigmaGraph.addNode(n, { x: dg._nodes[n].x, y: dg._nodes[n].y, label: n})
+  })
+  dg.edges().forEach((e) => {
+    sigmaGraph.addEdge(e.v, e.w)
+  })
+  //sigmaGraph.addNode(n, { x: Math.random(), y:Math.random(), label: output})
+  //sigmaGraph.addDirectedEdge(input, output)
+  return sigmaGraph
+
+}
+
+const GraphViewer: React.FC<{ graph: any }> = ({ graph }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const sigmaInstanceRef = useRef<Sigma | null>(null);
 
   useEffect(() => {
     // Create a graphology graph
-    const graph = new Graph();
-    graph.addNode("1", { label: "Node 1", x: 0, y: 0, size: 10, color: "blue" });
-    graph.addNode("2", { label: "Node 2", x: 1, y: 1, size: 20, color: "red" });
-    graph.addEdge("1", "2", { size: 5, color: "purple" });
+    console.log(graph);
+    window.ldgraph = graph;
+    let sigmaGraph = new Graph();
+    let allProcs = getAllProcesses(graph);
+    sigmaGraph = addNodesFromProcesses(allProcs, graph, sigmaGraph);
+    //doDagre();
 
     // Instantiate sigma.js and render the graph
     if (containerRef.current) {
-      sigmaInstanceRef.current = new Sigma(graph, containerRef.current);
+      window.graph = sigmaGraph;
+      sigmaInstanceRef.current = new Sigma(sigmaGraph, containerRef.current);
     }
 
     // Cleanup on unmount
@@ -31,7 +74,7 @@ const GraphViewer: React.FC = () => {
         sigmaInstanceRef.current = null;
       }
     };
-  }, []);
+  }, [graph]);
 
   return <div ref={containerRef} style={containerStyle} />;
 };

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -4,6 +4,7 @@ import { GraphView } from "./lib/GraphView";
 import { FormControl, SelectPanel, Button } from '@primer/react';
 import { TriangleDownIcon } from '@primer/octicons-react';
 import { type ActionListItemInput } from '@primer/react/deprecated';
+import { Table, DataTable } from '@primer/react/experimental';
 
 type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
 
@@ -20,12 +21,18 @@ const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
   const [selected, setSelected] = useState<ActionListItemInput | undefined>(undefined);
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState('');
+  const [hovered, setHovered] = useState<{ id: string, metadata: { [key: string]: string } } | null>(null);
 
   window.ldGraph = graph;
 
   useEffect(() => {
     if (containerRef.current) {
-      graphViewRef.current = new GraphView(graph, containerRef.current);
+      graphViewRef.current = new GraphView(
+        graph,
+        containerRef.current,
+        node => setHovered({ id: node.id, metadata: node.metadata }),
+        edge => setHovered({ id: edge.id, metadata: edge.metadata })
+      );
       window.sigmaGraph = graphViewRef.current;
       const locs = graphViewRef.current.getLocations(false).map(id => ({ text: id, id }));
       setLocations(locs);
@@ -40,7 +47,7 @@ const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
 
   // @TODO show metadta using https://primer.style/product/components/data-table/
   return (
-    <div>
+    <div style={{ position: "relative" }}>
       <FormControl>
         <FormControl.Label htmlFor="rp" id="selectLabel-location">
           Go to location
@@ -71,6 +78,50 @@ const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
       </FormControl>
       <div style={{ marginTop: 8 }} />
       <div ref={containerRef} style={containerStyle} />
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          bottom: 0,
+          margin: 16,
+          zIndex: 10,
+          background: "white",
+          borderRadius: 8,
+          boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+          minWidth: 240,
+          maxWidth: 360,
+          maxHeight: 300,
+          overflow: "auto",
+          padding: 12,
+        }}
+      >
+        {hovered && (
+          <Table.Container>
+            <Table.Title as="h2" id="metadata-table" style={{ fontSize: 16, marginBottom: 8 }}>
+              Metadata for <span style={{ fontWeight: 600 }}>{hovered.id}</span>
+            </Table.Title>
+            <DataTable
+              aria-labelledby="metadata-table"
+              data={Object.entries(hovered.metadata).map(([key, value], idx) => ({
+                id: idx,
+                key,
+                value,
+              }))}
+              columns={[
+                {
+                  header: 'Key',
+                  field: 'key',
+                  rowHeader: true,
+                },
+                {
+                  header: 'Value',
+                  field: 'value',
+                },
+              ]}
+            />
+          </Table.Container>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -21,7 +21,7 @@ const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
   const [selected, setSelected] = useState<ActionListItemInput | undefined>(undefined);
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState('');
-  const [hovered, setHovered] = useState<{ id: string, metadata: { [key: string]: string } } | null>(null);
+  const [hovered, setHovered] = useState<{ id: string, metadata: { [key: string]: string }, input?:string, output?:string } | null>(null);
 
   window.ldGraph = graph;
 
@@ -31,7 +31,7 @@ const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
         graph,
         containerRef.current,
         node => setHovered({ id: node.id, metadata: node.metadata }),
-        edge => setHovered({ id: edge.id, metadata: edge.metadata })
+        edge => setHovered({ id: edge.id, metadata: edge.metadata , input: edge.source, output: edge.target})
       );
       window.sigmaGraph = graphViewRef.current;
       const locs = graphViewRef.current.getLocations(false).map(id => ({ text: id, id }));
@@ -100,6 +100,37 @@ const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
             <Table.Title as="h2" id="metadata-table" style={{ fontSize: 16, marginBottom: 8 }}>
               Metadata for <span style={{ fontWeight: 600 }}>{hovered.id}</span>
             </Table.Title>
+            {(hovered.input || hovered.output) && (
+              <div style={{ marginBottom: 8 }}>
+                {hovered.input && (
+                  <Button
+                    size="small"
+                    variant="invisible"
+                    onClick={() => {
+                      if (graphViewRef.current) {
+                        graphViewRef.current.zoomToLocation(hovered.input!);
+                      }
+                    }}
+                    style={{ marginRight: 8 }}
+                  >
+                    Jump to input
+                  </Button>
+                )}
+                {hovered.output && (
+                  <Button
+                    size="small"
+                    variant="invisible"
+                    onClick={() => {
+                      if (graphViewRef.current) {
+                        graphViewRef.current.zoomToLocation(hovered.output!);
+                      }
+                    }}
+                  >
+                    Jump to output
+                  </Button>
+                )}
+              </div>
+            )}
             <DataTable
               aria-labelledby="metadata-table"
               data={Object.entries(hovered.metadata).map(([key, value], idx) => ({

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -5,7 +5,7 @@ import { GraphView } from "./lib/GraphView";
 type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
 
 const containerStyle: React.CSSProperties = {
-  width: "800px",
+  width: "100%",
   height: "600px",
   background: "white",
 };

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from "react";
+import Sigma from "sigma";
+import Graph from "graphology";
+
+const containerStyle: React.CSSProperties = {
+  width: "800px",
+  height: "600px",
+  background: "white",
+};
+
+const GraphViewer: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const sigmaInstanceRef = useRef<Sigma | null>(null);
+
+  useEffect(() => {
+    // Create a graphology graph
+    const graph = new Graph();
+    graph.addNode("1", { label: "Node 1", x: 0, y: 0, size: 10, color: "blue" });
+    graph.addNode("2", { label: "Node 2", x: 1, y: 1, size: 20, color: "red" });
+    graph.addEdge("1", "2", { size: 5, color: "purple" });
+
+    // Instantiate sigma.js and render the graph
+    if (containerRef.current) {
+      sigmaInstanceRef.current = new Sigma(graph, containerRef.current);
+    }
+
+    // Cleanup on unmount
+    return () => {
+      if (sigmaInstanceRef.current) {
+        sigmaInstanceRef.current.kill();
+        sigmaInstanceRef.current = null;
+      }
+    };
+  }, []);
+
+  return <div ref={containerRef} style={containerStyle} />;
+};
+
+export default GraphViewer;

--- a/src/components/GraphViewer/index.tsx
+++ b/src/components/GraphViewer/index.tsx
@@ -1,12 +1,8 @@
 import React, { useEffect, useRef } from "react";
-import { JsonController, ROCrate } from '@nfdi4plants/arctrl'
-import Sigma from "sigma";
-import Graph from "graphology";
-import dagre from "@dagrejs/dagre";
+import { JsonController } from '@nfdi4plants/arctrl'
+import { GraphView } from "./lib/GraphView";
 
 type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
-type LDContext = Parameters<typeof ROCrate.LDLabProcess.validate>[1];
-type LDNode = Parameters<typeof ROCrate.LDLabProcess.validate>[0];
 
 const containerStyle: React.CSSProperties = {
   width: "800px",
@@ -14,158 +10,21 @@ const containerStyle: React.CSSProperties = {
   background: "white",
 };
 
-type Node = {
-  id: string;
-  label: string;
-  type: string;
-  x?: number;
-  y?: number;
-};
-
-type Edge = {
-  id: string;
-  label: string;
-  source: string;
-  target: string;
-};
-
-/**
- * Returns all nodes in the LDGraph that are valid Lab Processes.
- *
- * @param ldGraph - The LDGraph instance to search for processes.
- * @returns An array of nodes that are validated as Lab Processes.
- * @throws Error if no context is found in the LDGraph.
- */
- function getAllProcesses(ldGraph: LDGraph, context: LDContext): LDNode[] {
-   const processes = ldGraph.Nodes.filter(
-     node => ROCrate.LDLabProcess.validate(node, context)
-   );
-   return processes;
- }
-
-function nodesAndEdgesFromProcesses(processes: LDNode[], ldGraph: LDGraph, context: LDContext) {
-  const nodes: Node[] = [];
-  const edges: Edge[] = [];
-
-  processes.forEach((process) => {
-    const id = process.id;
-
-    const inputs = ROCrate.LDLabProcess.getObjects(process, ldGraph, context as LDContext);
-    const outputs = ROCrate.LDLabProcess.getResults(process, ldGraph, context as LDContext);
-
-    if (inputs.length > 0 && outputs.length > 0) {
-      let label = id;
-      let protocol = ROCrate.LDLabProcess.tryGetExecutesLabProtocol(process, ldGraph, context);
-      if(protocol) {
-        protocol = protocol as LDNode;
-        const name = ROCrate.LDLabProtocol.tryGetNameAsString(protocol, context);
-        label = name ? name as string : protocol.id;
-      }
-      edges.push({ id, label, source: inputs[0].id, target: outputs[0].id });
-
-      const input = inputs[0];
-      const output = outputs[0];
-
-      // Only add unique nodes
-      if (!nodes.some(n => n.id === input.id)) {
-        nodes.push({ id: input.id, label: input.id, type: input.AdditionalType[0] || input.SchemaType[0] });
-      }
-      if (!nodes.some(n => n.id === output.id)) {
-        nodes.push({ id: output.id, label: output.id, type: output.AdditionalType[0] || output.SchemaType[0] });
-      }
-    }
-  });
-
-  return { nodes, edges };
-}
-
-function layoutNodes(nodes: Node[], edges: Edge[]) {
-  const dg = new dagre.graphlib.Graph()
-  dg.setGraph({ rankdir: 'LR' })
-  dg.setDefaultEdgeLabel(function() { return {}; }); // somehow needed
-
-  nodes.forEach((node) => {
-    dg.setNode(node.id, { label: node.label, width: 20, height: 20 });
-  })
-
-  edges.forEach((edge) => {
-    dg.setEdge(edge.source, edge.target, { label: edge.label });
-  })
-
-  dagre.layout(dg)
-
-  nodes.forEach((node) => {
-    const { x, y } = dg.node(node.id);
-    node.x = x;
-    node.y = y;
-  })
-}
-
-function buildSigmaGraph(graph: LDGraph) {
-  let context = graph.TryGetContext();
-  if(!context) throw new Error("No context found in LDGraph.");
-  context = context as LDContext;
-
-  const processes = getAllProcesses(graph, context);
-  const { nodes, edges } = nodesAndEdgesFromProcesses(processes, graph, context);
-  window.nodes = nodes;
-  window.edges = edges;
-  layoutNodes(nodes, edges);
-
-  const sigmaGraph = new Graph();
-  nodes.forEach((node) => {
-    let color: string;
-    let size: number;
-    switch (node.type) {
-      case "Source":
-        color = "#3B734E";
-        size = 4;
-        break;
-      case "Sample":
-        color = "#2E68D3";
-        size = 3;
-        break;
-      case "File":
-        color = "#202328";
-        size = 2;
-        break;
-      default:
-        color = "black";
-        size = 2;
-        break;
-    }
-    sigmaGraph.addNode(node.id, { x: node.x, y: node.y, label: node.label, color, size })
-  })
-  edges.forEach((edge) => {
-    sigmaGraph.addDirectedEdge(edge.source, edge.target, { label: edge.label })
-  })
-  return sigmaGraph
-
-}
-
 const GraphViewer: React.FC<{ graph: LDGraph }> = ({ graph }) => {
-  window.ldGraph = graph;
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const sigmaInstanceRef = useRef<Sigma | null>(null);
+  const graphViewRef = useRef<GraphView | null>(null);
 
   useEffect(() => {
-    // Create a graphology graph
-    const sigmaGraph = buildSigmaGraph(graph);
-
-    // Instantiate sigma.js and render the graph
     if (containerRef.current) {
-      sigmaInstanceRef.current = new Sigma(sigmaGraph, containerRef.current, { renderEdgeLabels: true, defaultEdgeType: "arrow" });
-      // https://www.sigmajs.org/storybook/?path=/story/sigma-edge-curve--interactions
+      graphViewRef.current = new GraphView(graph, containerRef.current);
+      window.sigmaGraph = graphViewRef.current;
     }
-
-    window.ROCrate = ROCrate;
-    window.sigmaGraph = sigmaGraph;
 
     // Cleanup on unmount
     return () => {
-      if (sigmaInstanceRef.current) {
-        sigmaInstanceRef.current.kill();
-        sigmaInstanceRef.current = null;
+      if (graphViewRef.current) {
+        graphViewRef.current.destroy();
+        graphViewRef.current = null;
       }
     };
   }, [graph]);

--- a/src/components/GraphViewer/lib/GraphView.ts
+++ b/src/components/GraphViewer/lib/GraphView.ts
@@ -2,6 +2,7 @@ import Sigma from "sigma";
 import Graph from "graphology";
 import dagre from "@dagrejs/dagre";
 import { JsonController, ROCrate } from '@nfdi4plants/arctrl';
+import { type Option } from '@fable-org/fable-library-js/Option.js';
 
 type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
 type LDContext = Parameters<typeof ROCrate.LDLabProcess.validate>[1];
@@ -30,23 +31,24 @@ function getAllProcesses(ldGraph: LDGraph, context: LDContext): LDNode[] {
   );
 }
 
+function resolveOption<T>(opt: Option<T>, defaultValue: T): T {
+  return opt != null ? opt as T : defaultValue;
+}
+
 function getNodeMetadata(node: LDNode, ldGraph: LDGraph, context: LDContext): { [key: string]: string } {
   switch(node.SchemaType[0]) {
     case "Sample":
       return Object.fromEntries(ROCrate.LDSample.getAdditionalProperties(node, ldGraph, context).map(
         (s) => [
-          s.name, s.value
-// @TODO for some reason the below doesn't work, I don't understand why.
-//          ROCrate.LDPropertyValue.getNameAsString(s),
-//          ROCrate.LDPropertyValue.getValueAsString(s)
+          ROCrate.LDPropertyValue.getNameAsString(s, context),
+          resolveOption(ROCrate.LDPropertyValue.tryGetValueAsString(s, context), "")
         ]
       ));
     case "LabProcess":
       return Object.fromEntries(ROCrate.LDLabProcess.getParameterValues(node, ldGraph, context).map(
         (s) => [
-          s.name, s.value
-//          ROCrate.LDPropertyValue.getNameAsString(s),
-//          ROCrate.LDPropertyValue.getValueAsString(s)
+          ROCrate.LDPropertyValue.getNameAsString(s, context),
+          resolveOption(ROCrate.LDPropertyValue.tryGetValueAsString(s, context), "")
         ]
       ));
     case "File":
@@ -57,25 +59,26 @@ function getNodeMetadata(node: LDNode, ldGraph: LDGraph, context: LDContext): { 
   }
 }
 
-function nodesAndEdgesFromProcesses(processes: LDNode[], ldGraph: LDGraph, context: LDContext) {
+function buildNodesAndEdgesFromProcesses(
+  processes: LDNode[],
+  ldGraph: LDGraph,
+  context: LDContext
+): { nodes: { [id: string]: Node }; edges: { [id: string]: Edge } } {
   const nodes: { [id: string]: Node } = {};
   const edges: { [id: string]: Edge } = {};
-
-  window.ROCrate = ROCrate;
 
   processes.forEach((process) => {
     const id = process.id;
 
-    const inputs = ROCrate.LDLabProcess.getObjects(process, ldGraph, context as LDContext);
-    const outputs = ROCrate.LDLabProcess.getResults(process, ldGraph, context as LDContext);
+    const inputs = ROCrate.LDLabProcess.getObjects(process, ldGraph, context);
+    const outputs = ROCrate.LDLabProcess.getResults(process, ldGraph, context);
 
     if (inputs.length > 0 && outputs.length > 0) {
       let label = id;
       let protocol = ROCrate.LDLabProcess.tryGetExecutesLabProtocol(process, ldGraph, context);
-      if(protocol) {
+      if (protocol) {
         protocol = protocol as LDNode;
-        const name = ROCrate.LDLabProtocol.tryGetNameAsString(protocol, context);
-        label = name ? name as string : protocol.id;
+        label = resolveOption(ROCrate.LDLabProtocol.tryGetNameAsString(protocol, context), protocol.id);
       }
       edges[id] = {
         id,
@@ -107,19 +110,18 @@ function nodesAndEdgesFromProcesses(processes: LDNode[], ldGraph: LDGraph, conte
     }
   });
 
-  // @TODO
-  window.nodes = nodes;
-  window.edges = edges;
   return { nodes, edges };
 }
 
 function layoutNodes(nodes: { [id: string]: Node }, edges: { [id: string]: Edge }) {
   const dg = new dagre.graphlib.Graph();
-  dg.setGraph({ rankdir: 'LR' });
-  dg.setDefaultEdgeLabel(function() { return {}; });
+  dg.setGraph({
+    rankdir: 'LR',
+  });
+  dg.setDefaultEdgeLabel(function () { return {}; });
 
   Object.values(nodes).forEach((node) => {
-    dg.setNode(node.id, { label: node.label, width: 20, height: 20 });
+    dg.setNode(node.id, { label: node.label, width: 2, height: 2 });
   });
 
   Object.values(edges).forEach((edge) => {
@@ -128,38 +130,102 @@ function layoutNodes(nodes: { [id: string]: Node }, edges: { [id: string]: Edge 
 
   dagre.layout(dg);
 
+  // Find min/max for normalization
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
   Object.values(nodes).forEach((node) => {
     const { x, y } = dg.node(node.id);
-    node.x = x;
-    node.y = y;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
   });
-}
 
-function buildSigmaGraph(graph: LDGraph, context: LDContext): Graph {
-  const processes = getAllProcesses(graph, context);
-  const { nodes, edges } = nodesAndEdgesFromProcesses(processes, graph, context);
-  layoutNodes(nodes, edges);
+  // Avoid division by zero
+  const dx = maxX - minX || 1;
+  const dy = maxY - minY || 1;
 
-  const sigmaGraph = new Graph();
   Object.values(nodes).forEach((node) => {
-    sigmaGraph.addNode(node.id, { x: node.x, y: node.y, label: node.label });
+    const { x, y } = dg.node(node.id);
+    node.x = (x - minX) / dx;
+    node.y = (y - minY) / dy;
   });
-  Object.values(edges).forEach((edge) => {
-    sigmaGraph.addDirectedEdge(edge.source, edge.target, { label: edge.label });
-  });
-  return sigmaGraph;
 }
 
 export class GraphView {
   private sigmaInstance: Sigma | null = null;
+  private nodes: { [id: string]: Node } = {};
+  private edges: { [id: string]: Edge } = {};
 
   constructor(graph: LDGraph, domElement: HTMLElement) {
     let context = graph.TryGetContext();
-    if(!context) throw new Error("No context found in LDGraph.");
+    if (!context) throw new Error("No context found in LDGraph.");
     context = context as LDContext;
 
-    const sigmaGraph = buildSigmaGraph(graph, context);
-    this.sigmaInstance = new Sigma(sigmaGraph, domElement, { renderEdgeLabels: true, defaultEdgeType: "arrow" });
+    const processes = getAllProcesses(graph, context);
+    const { nodes, edges } = buildNodesAndEdgesFromProcesses(processes, graph, context);
+    this.nodes = nodes;
+    this.edges = edges;
+
+    // @TODO
+    window.ROCrate = ROCrate;
+    window.nodes = this.nodes;
+    window.edges = this.edges;
+
+    layoutNodes(this.nodes, this.edges);
+
+    const sigmaGraph = new Graph();
+    Object.values(this.nodes).forEach((node) => {
+      sigmaGraph.addNode(node.id, { x: node.x, y: node.y, label: node.label });
+    });
+    Object.values(this.edges).forEach((edge) => {
+      sigmaGraph.addDirectedEdge(edge.source, edge.target, { label: edge.label });
+    });
+    this.sigmaInstance = new Sigma(sigmaGraph, domElement, {
+      renderEdgeLabels: true,
+      defaultEdgeType: "arrow",
+      labelRenderedSizeThreshold: 4,
+    });
+  }
+
+  zoomToLocation(id: string) {
+    if (!this.sigmaInstance) return;
+
+    // Try node first
+    const node = this.nodes[id];
+    if (node) {
+      if (node.x === undefined || node.y === undefined) {
+        throw new Error("Node position is undefined. You need to layout the graph first.");
+      }
+      console.log(node)
+      this.sigmaInstance.getCamera().animate(
+        { x: node.x, y: node.y, ratio: 0.2 },
+        { duration: 600 }
+      );
+      return;
+    }
+
+    // Try edge
+    const edge = this.edges[id];
+    if (edge) {
+      const source = this.nodes[edge.source];
+      const target = this.nodes[edge.target];
+      if (!source || !target || source.x === undefined || source.y === undefined || target.x === undefined || target.y === undefined) {
+        throw new Error("Edge endpoint position is undefined. You need to layout the graph first.");
+      }
+      // Center between source and target
+      const x = (source.x + target.x) / 2;
+      const y = (source.y + target.y) / 2;
+      this.sigmaInstance.getCamera().animate(
+        { x, y, ratio: 0.2 },
+        { duration: 600 }
+      );
+    }
+  }
+
+  getLocations(includeEdges = false): string[] {
+    const nodeIds = Object.keys(this.nodes);
+    if (!includeEdges) return nodeIds;
+    return nodeIds.concat(Object.keys(this.edges));
   }
 
   destroy() {

--- a/src/components/GraphViewer/lib/GraphView.ts
+++ b/src/components/GraphViewer/lib/GraphView.ts
@@ -1,0 +1,120 @@
+import Sigma from "sigma";
+import Graph from "graphology";
+import dagre from "@dagrejs/dagre";
+import { JsonController, ROCrate } from '@nfdi4plants/arctrl';
+
+type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
+type LDContext = Parameters<typeof ROCrate.LDLabProcess.validate>[1];
+type LDNode = Parameters<typeof ROCrate.LDLabProcess.validate>[0];
+
+type Node = {
+  id: string;
+  label: string;
+  x?: number;
+  y?: number;
+};
+
+type Edge = {
+  id: string;
+  label: string;
+  source: string;
+  target: string;
+};
+
+function getAllProcesses(ldGraph: LDGraph, context: LDContext): LDNode[] {
+  return ldGraph.Nodes.filter(
+    node => ROCrate.LDLabProcess.validate(node, context)
+  );
+}
+
+function nodesAndEdgesFromProcesses(processes: LDNode[], ldGraph: LDGraph, context: LDContext) {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  processes.forEach((process) => {
+    const id = process.id;
+
+    const inputs = ROCrate.LDLabProcess.getObjects(process, ldGraph, context as LDContext);
+    const outputs = ROCrate.LDLabProcess.getResults(process, ldGraph, context as LDContext);
+
+    if (inputs.length > 0 && outputs.length > 0) {
+      let label = id;
+      let protocol = ROCrate.LDLabProcess.tryGetExecutesLabProtocol(process, ldGraph, context);
+      if(protocol) {
+        protocol = protocol as LDNode;
+        const name = ROCrate.LDLabProtocol.tryGetNameAsString(protocol, context);
+        label = name ? name as string : protocol.id;
+      }
+      edges.push({ id, label, source: inputs[0].id, target: outputs[0].id });
+
+      const input = inputs[0];
+      const output = outputs[0];
+
+      if (!nodes.some(n => n.id === input.id)) {
+        nodes.push({ id: input.id, label: input.id });
+      }
+      if (!nodes.some(n => n.id === output.id)) {
+        nodes.push({ id: output.id, label: output.id });
+      }
+    }
+  });
+
+  return { nodes, edges };
+}
+
+function layoutNodes(nodes: Node[], edges: Edge[]) {
+  const dg = new dagre.graphlib.Graph();
+  dg.setGraph({ rankdir: 'LR' });
+  dg.setDefaultEdgeLabel(function() { return {}; });
+
+  nodes.forEach((node) => {
+    dg.setNode(node.id, { label: node.label, width: 20, height: 20 });
+  });
+
+  edges.forEach((edge) => {
+    dg.setEdge(edge.source, edge.target, { label: edge.label });
+  });
+
+  dagre.layout(dg);
+
+  nodes.forEach((node) => {
+    const { x, y } = dg.node(node.id);
+    node.x = x;
+    node.y = y;
+  });
+}
+
+function buildSigmaGraph(graph: LDGraph): Graph {
+  let context = graph.TryGetContext();
+  if(!context) throw new Error("No context found in LDGraph.");
+  context = context as LDContext;
+
+  const processes = getAllProcesses(graph, context);
+  const { nodes, edges } = nodesAndEdgesFromProcesses(processes, graph, context);
+  layoutNodes(nodes, edges);
+
+  const sigmaGraph = new Graph();
+  nodes.forEach((node) => {
+    sigmaGraph.addNode(node.id, { x: node.x, y: node.y, label: node.label });
+  });
+  edges.forEach((edge) => {
+    sigmaGraph.addDirectedEdge(edge.source, edge.target, { label: edge.label });
+  });
+  return sigmaGraph;
+}
+
+export class GraphView {
+  private sigmaInstance: Sigma | null = null;
+
+  constructor(graph: LDGraph, domElement: HTMLElement) {
+    const sigmaGraph = buildSigmaGraph(graph);
+    this.sigmaInstance = new Sigma(sigmaGraph, domElement, { renderEdgeLabels: true, defaultEdgeType: "arrow" });
+  }
+
+  destroy() {
+    if (this.sigmaInstance) {
+      this.sigmaInstance.kill();
+      this.sigmaInstance = null;
+    }
+  }
+}

--- a/src/components/WebViewer/index.tsx
+++ b/src/components/WebViewer/index.tsx
@@ -14,6 +14,7 @@ import ARCMetadata from '../Metadata/ARCMetadata'
 import FileTree from '../FileTree'
 import Icons from '../Icons'
 import {XCircleIcon} from '@primer/octicons-react'
+import GraphViewer from '../GraphViewer'
 
 function pathsToFileTree(paths: string[], exportMetadataMap: Map<string, ARCExportMetadata>) {
   const root: TreeNode = { name: "root", id: "", type: "folder", children: [] };
@@ -68,7 +69,7 @@ function findNodeAtPath(tree: TreeNode, targetPath: string): TreeNode | null {
 }
 
 // async function findReadme(tree: TreeNode): Promise<string> {
-//   if (tree.name !== "root") 
+//   if (tree.name !== "root")
 //     return "No Readme found";
 //   return readme;
 // }
@@ -112,8 +113,8 @@ async function asyncDataToSearchCache(tree: TreeNode, arc: ARC, setCache: React.
       table.Headers.forEach(header => {
         const term = header.TryGetTerm();
         if (!term) {
-          headers.add({ name: header.toString(), path, type: "header" });        
-        } 
+          headers.add({ name: header.toString(), path, type: "header" });
+        }
         if (term) {
           const nametext = (term as OntologyAnnotation).NameText;
           if (nametext) {
@@ -356,7 +357,7 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
   }, [setCache, jsonString])
 
   const expandedFolderIds = useMemo(() => {
-    return currentTreeNode?.id ? findPathToNode(tree?.children || [], currentTreeNode.id) ?? [] : []; 
+    return currentTreeNode?.id ? findPathToNode(tree?.children || [], currentTreeNode.id) ?? [] : [];
   }, [tree, currentTreeNode]);
 
   const renderedTree = useMemo(() => (
@@ -374,16 +375,17 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
           </SideSheet>
         )}
       </div>
-      <SplitPageLayout.Pane 
-        aria-label="Sidebar" 
-        resizable={true} 
+      <SplitPageLayout.Pane
+        aria-label="Sidebar"
+        resizable={true}
         widthStorageKey={"arc-webviewer-sidebar-width"}
-        hidden={!sidebarActive || isSmallScreen as boolean} 
+        hidden={!sidebarActive || isSmallScreen as boolean}
         sticky={true}
       >
         {renderedTree}
       </SplitPageLayout.Pane>
       <SplitPageLayout.Content>
+        <GraphViewer />
         <Stack>
           <div className="bgColor-default py-2 position-sticky top-0 z-1 d-flex flex-items-start">
             <Stack className="flex-column flex-sm-row flex-items-start flex-sm-items-center" style={{width: "100%"}}>
@@ -399,7 +401,7 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
           </div>
           {
             currentTreeNode && currentTreeNode.type === 'file' && arc
-              ? (renderFileComponentByName(currentTreeNode, arc)) 
+              ? (renderFileComponentByName(currentTreeNode, arc))
               : <FileTable loading={loading} currentTreeNode={currentTreeNode} navigateTo={navigateTo} />
           }
           {tree && currentTreeNode && currentTreeNode.name === "root" && currentTreeNode.type === 'folder' &&

--- a/src/components/WebViewer/index.tsx
+++ b/src/components/WebViewer/index.tsx
@@ -15,6 +15,7 @@ import FileTree from '../FileTree'
 import Icons from '../Icons'
 import {XCircleIcon} from '@primer/octicons-react'
 import GraphViewer from '../GraphViewer'
+import {WorkflowIcon} from '@primer/octicons-react'
 
 function pathsToFileTree(paths: string[], exportMetadataMap: Map<string, ARCExportMetadata>) {
   const root: TreeNode = { name: "root", id: "", type: "folder", children: [] };
@@ -317,6 +318,7 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
   const {setCache} = useSearchCacheContext()
 
   const [sidebarActive, setSidebarActive] = useState(false);
+  const [graphPaneActive, setGraphPaneActive] = useState(false);
 
   const isSmallScreen = useResponsiveValue({
     narrow: true,
@@ -387,7 +389,15 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
         {renderedTree}
       </SplitPageLayout.Pane>
       <SplitPageLayout.Content>
-        {graph && <GraphViewer graph={graph} />}
+        {graphPaneActive && (
+          <Dialog
+            title="Graph Viewer"
+            onClose={() => setGraphPaneActive(false)}
+            position="right"
+          >
+            {graph && <GraphViewer graph={graph} />}
+          </Dialog>
+        )}
         <Stack>
           <div className="bgColor-default py-2 position-sticky top-0 z-1 d-flex flex-items-start">
             <Stack className="flex-column flex-sm-row flex-items-start flex-sm-items-center" style={{width: "100%"}}>
@@ -396,9 +406,17 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
                 <TreeSearch navigateTo={navigateTo} />
               </div>
               {currentTreeNode && arc && arc.Title && <FileBreadcrumbs currentTreeNode={currentTreeNode} navigateTo={navigateTo} title={arc.Title} />}
-              {clearJsonCallback &&
-                <IconButton style={{ marginLeft: "auto" }} aria-label="Clear loaded JSON and upload new" variant='danger' icon={XCircleIcon} onClick={() => clearJsonCallback()} />
-              }
+              <div style={{ marginLeft: "auto", display: "flex", gap: "0.5rem" }}>
+                <IconButton
+                  aria-label="Show Graph Viewer"
+                  variant="invisible"
+                  icon={WorkflowIcon}
+                  onClick={() => setGraphPaneActive(true)}
+                />
+                {clearJsonCallback &&
+                  <IconButton aria-label="Clear loaded JSON and upload new" variant='danger' icon={XCircleIcon} onClick={() => clearJsonCallback()} />
+                }
+              </div>
             </Stack>
           </div>
           {

--- a/src/components/WebViewer/index.tsx
+++ b/src/components/WebViewer/index.tsx
@@ -311,6 +311,7 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
 
   const [arc, setArc] = useState<ARC | null>(null)
   const [tree, setTree] = useState<TreeNode | null>(null)
+  const [graph, setGraph] = useState<any>(null);
   const [currentTreeNode, setCurrentTreeNode] = useState<TreeNode | null>(null)
   const [loading, setLoading] = useState(true)
   const {setCache} = useSearchCacheContext()
@@ -335,13 +336,14 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
   useEffect(() => {
     // This is just to simulate a data fetch, in a real application you would fetch this
     // data from an API or some other source.
-    const g = JsonController.LDGraph.fromROCrateJsonString(jsonString);
+    const graphObj = JsonController.LDGraph.fromROCrateJsonString(jsonString);
+    setGraph(graphObj);
     const arc = JsonController.ARC.fromROCrateJsonString(jsonString);
-    const files = g.Nodes.filter(n => ROCrate.LDFile.validate(n, g.TryGetContext() as any));
+    const files = graphObj.Nodes.filter(n => ROCrate.LDFile.validate(n, graphObj.TryGetContext() as any));
     const fileIdExportMetadataMap = new Map<string, ARCExportMetadata>();
     files.forEach(file => {
       const id = file.id;
-      const sha = file.TryGetProperty('http://schema.org/sha256', g.TryGetContext() as any) || file.TryGetProperty('https://schema.org/sha256', g.TryGetContext() as any);
+      const sha = file.TryGetProperty('http://schema.org/sha256', graphObj.TryGetContext() as any) || file.TryGetProperty('https://schema.org/sha256', graphObj.TryGetContext() as any);
       if (id && sha) {
         const contentSize = file.TryGetProperty("contentSize");
         fileIdExportMetadataMap.set(id, { sha256: sha, contentSize: contentSize ? formatFileSize(contentSize) : undefined });
@@ -385,7 +387,7 @@ export default function WebViewer({ jsonString, readmefetch, licensefetch, clear
         {renderedTree}
       </SplitPageLayout.Pane>
       <SplitPageLayout.Content>
-        <GraphViewer />
+        {graph && <GraphViewer graph={graph} />}
         <Stack>
           <div className="bgColor-default py-2 position-sticky top-0 z-1 d-flex flex-items-start">
             <Stack className="flex-column flex-sm-row flex-items-start flex-sm-items-center" style={{width: "100%"}}>


### PR DESCRIPTION
This is far away from being ready to merge but I/we at the Hackathon thought it would be nice to have a way to interactively explore the ARC process graph on the ARChive page where this component is used. I'm envisioning different shapes/colors for sources/samples/data and a little "table" or something which displays the characteristics/parameters etc. when you hover over the node or edge. Ideally the graph should also be searchable (and then jump to the specific node and/or highlight the relevant path or something) and in the further future we could integrate it with the current component so that you can e.g. click on nodes to get to the respective file or row in the assay/study table and vice versa.

As I said, far from being mature enough but I wanted to make it visible early @Freymaurer and get your input if you like