### PR TITLE
implement basic file provenance viewer

### DIFF
--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useId, useRef } from 'react';
+import { useState, useEffect, useId } from 'react';
 import mermaid from '../../util/mermaid';
 import { Table, DataTable, type UniqueRow, type Column } from '@primer/react/experimental';
 import { JsonController, ROCrate } from '@nfdi4plants/arctrl';
@@ -216,21 +216,17 @@ function generateMermaidDiagram(graph: ProvenanceGraph): string {
 
 interface FileProvenanceViewerProps {
   fileNode?: TreeNode;
-  onClose?: () => void;
   ldGraph?: LDGraph;
 }
 
 export default function FileProvenanceViewer({
   fileNode,
-  onClose,
   ldGraph
 }: FileProvenanceViewerProps) {
-  const fileName = fileNode?.name || 'output.fastq';
   const [activeTab, setActiveTab] = useState<'diagram' | 'details'>('diagram');
   const [svgContent, setSvgContent] = useState<string>('');
   const [provenance, setProvenance] = useState<ProvenanceGraph | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const mermaidRef = useRef<HTMLDivElement>(null);
   const renderId = `provenance-${useId().replace(/[^\w-]/g, '')}`;
 
   useEffect(() => {
@@ -278,18 +274,8 @@ export default function FileProvenanceViewer({
 
   if (error || !provenance) {
     return (
-      <div
-        style={{
-          backgroundColor: 'white',
-          borderRadius: '8px',
-          boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
-          maxWidth: '1000px',
-          maxHeight: '90vh',
-          padding: '24px',
-          textAlign: 'center',
-        }}
-      >
-        <h2 style={{ margin: '0 0 12px 0' }}>No Provenance Available</h2>
+      <div style={{ padding: '24px', textAlign: 'center' }}>
+        <h3 style={{ margin: '0 0 12px 0' }}>No Provenance Available</h3>
         <p style={{ margin: 0, color: '#666' }}>
           {error || "Could not load provenance data for this file."}
         </p>
@@ -298,45 +284,7 @@ export default function FileProvenanceViewer({
   }
 
   return (
-    <div
-      style={{
-        backgroundColor: 'white',
-        borderRadius: '8px',
-        boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
-        maxWidth: '1000px',
-        maxHeight: '90vh',
-        overflow: 'hidden',
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
-      <div style={{ padding: '12px 16px', borderBottom: '1px solid #e1e4e8', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <div>
-          <h2 style={{ margin: '0 0 2px 0', fontSize: '1.3em' }}>File Provenance</h2>
-          <p style={{ margin: 0, fontSize: '0.85em', color: '#666' }}>{fileName}</p>
-        </div>
-        {onClose && (
-          <button
-            onClick={onClose}
-            style={{
-              background: 'none',
-              border: 'none',
-              fontSize: '1.5em',
-              cursor: 'pointer',
-              color: '#666',
-              padding: '0',
-              width: '32px',
-              height: '32px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            ✕
-          </button>
-        )}
-      </div>
-
+    <div>
       <div style={{ display: 'flex', borderBottom: '1px solid #e1e4e8' }}>
         <button
           onClick={() => setActiveTab('diagram')}
@@ -372,9 +320,8 @@ export default function FileProvenanceViewer({
         </button>
       </div>
 
-      <div style={{ flex: 1, overflowY: 'auto', padding: '16px', display: activeTab === 'diagram' ? 'block' : 'none' }}>
+      <div style={{ padding: '16px', display: activeTab === 'diagram' ? 'block' : 'none' }}>
         <div
-          ref={mermaidRef}
           dangerouslySetInnerHTML={{ __html: svgContent }}
           style={{
             display: 'flex',
@@ -385,7 +332,7 @@ export default function FileProvenanceViewer({
         />
       </div>
 
-      <div style={{ flex: 1, overflowY: 'auto', padding: '12px', display: activeTab === 'details' ? 'block' : 'none', fontSize: '0.9em' }}>
+      <div style={{ padding: '12px', display: activeTab === 'details' ? 'block' : 'none', fontSize: '0.9em' }}>
         <div>
           <h3 style={{ margin: '0 0 8px 0', fontSize: '1em', borderBottom: '2px solid #e1e4e8', paddingBottom: '4px' }}>Nodes</h3>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>

--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -112,55 +112,50 @@ function extractProvenance(ldGraph: LDGraph): ProvenanceGraph | null {
 
     const processes = getAllProcesses(ldGraph, context as LDContext);
 
+    const addNodeIfMissing = (node: LDNode) => {
+      if (!nodeMap[node.id]) {
+        const provNode: ProvenanceNode = {
+          id: node.id,
+          label: node.id,
+          type: node.AdditionalType?.[0] || node.SchemaType?.[0] || "Unknown",
+          metadata: extractNodeMetadata(node, ldGraph, context as LDContext),
+        };
+        nodeMap[node.id] = provNode;
+        nodes.push(provNode);
+      }
+    };
+
     processes.forEach((process) => {
       const inputs = ROCrate.LDLabProcess.getObjects(process, ldGraph, context as LDContext);
       const outputs = ROCrate.LDLabProcess.getResults(process, ldGraph, context as LDContext);
 
-      if (inputs.length > 0 && outputs.length > 0) {
-        const input = inputs[0];
-        const output = outputs[0];
+      if (inputs.length === 0 || outputs.length === 0) return;
 
-        // Add input node if not exists
-        if (!nodeMap[input.id]) {
-          const inputNode: ProvenanceNode = {
-            id: input.id,
-            label: input.id,
-            type: input.AdditionalType?.[0] || input.SchemaType?.[0] || "Unknown",
-            metadata: extractNodeMetadata(input, ldGraph, context as LDContext),
-          };
-          nodeMap[input.id] = inputNode;
-          nodes.push(inputNode);
-        }
-
-        // Add output node if not exists
-        if (!nodeMap[output.id]) {
-          const outputNode: ProvenanceNode = {
-            id: output.id,
-            label: output.id,
-            type: output.AdditionalType?.[0] || output.SchemaType?.[0] || "Unknown",
-            metadata: extractNodeMetadata(output, ldGraph, context as LDContext),
-          };
-          nodeMap[output.id] = outputNode;
-          nodes.push(outputNode);
-        }
-
-        // Add edge
-        let processLabel = process.id;
-        const protocol = ROCrate.LDLabProcess.tryGetExecutesLabProtocol(process, ldGraph, context as LDContext);
-        if (protocol) {
-          processLabel = resolveOption(
-            ROCrate.LDLabProtocol.tryGetNameAsString(protocol as LDNode, context as LDContext),
-            (protocol as LDNode).id
-          );
-        }
-
-        edges.push({
-          from: input.id,
-          to: output.id,
-          label: processLabel,
-          metadata: extractNodeMetadata(process, ldGraph, context as LDContext),
-        });
+      let processLabel = process.id;
+      const protocol = ROCrate.LDLabProcess.tryGetExecutesLabProtocol(process, ldGraph, context as LDContext);
+      if (protocol) {
+        processLabel = resolveOption(
+          ROCrate.LDLabProtocol.tryGetNameAsString(protocol as LDNode, context as LDContext),
+          (protocol as LDNode).id
+        );
       }
+      const processMetadata = extractNodeMetadata(process, ldGraph, context as LDContext);
+
+      inputs.forEach(addNodeIfMissing);
+      outputs.forEach(addNodeIfMissing);
+
+      // In ARC data, processes are flattened to 1:1, but the ROCrate spec
+      // permits input/output arrays — emit an edge for every input×output pair.
+      inputs.forEach((input) => {
+        outputs.forEach((output) => {
+          edges.push({
+            from: input.id,
+            to: output.id,
+            label: processLabel,
+            metadata: processMetadata,
+          });
+        });
+      });
     });
 
     return { nodes, edges };

--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useId, useRef } from 'react';
 import mermaid from '../../util/mermaid';
 import { Table, DataTable, type UniqueRow, type Column } from '@primer/react/experimental';
 import { JsonController, ROCrate } from '@nfdi4plants/arctrl';
@@ -232,6 +232,7 @@ export default function FileProvenanceViewer({
   const [provenance, setProvenance] = useState<ProvenanceGraph | null>(null);
   const [error, setError] = useState<string | null>(null);
   const mermaidRef = useRef<HTMLDivElement>(null);
+  const renderId = `provenance-${useId().replace(/[^\w-]/g, '')}`;
 
   useEffect(() => {
     if (!ldGraph) {
@@ -266,7 +267,7 @@ export default function FileProvenanceViewer({
     const renderDiagram = async () => {
       try {
         const mermaidCode = generateMermaidDiagram(provenance);
-        const { svg } = await mermaid.render('provenance-diagram', mermaidCode);
+        const { svg } = await mermaid.render(renderId, mermaidCode);
         setSvgContent(svg);
       } catch (error) {
         console.error('Error rendering Mermaid diagram:', error);
@@ -274,7 +275,7 @@ export default function FileProvenanceViewer({
       }
     };
     renderDiagram();
-  }, [provenance]);
+  }, [provenance, renderId]);
 
   if (error || !provenance) {
     return (

--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -1,0 +1,487 @@
+import { useState, useEffect, useRef } from 'react';
+import mermaid from 'mermaid';
+import { Table, DataTable, type UniqueRow, type Column } from '@primer/react/experimental';
+import { JsonController, ROCrate } from '@nfdi4plants/arctrl';
+import type { TreeNode } from '../../util/types';
+
+// Types
+interface ProvenanceNode {
+  id: string;
+  label: string;
+  type: string;
+  metadata: Record<string, string>;
+}
+
+interface ProvenanceEdge {
+  from: string;
+  to: string;
+  label: string;
+  metadata: Record<string, string>;
+}
+
+interface ProvenanceGraph {
+  nodes: ProvenanceNode[];
+  edges: ProvenanceEdge[];
+}
+
+type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
+type LDContext = Parameters<typeof ROCrate.LDLabProcess.validate>[1];
+type LDNode = Parameters<typeof ROCrate.LDLabProcess.validate>[0];
+
+mermaid.initialize({
+  startOnLoad: false,
+  theme: 'default',
+  flowchart: {
+    padding: 10,
+    nodeSpacing: 30,
+    rankSpacing: 40,
+  },
+  securityLevel: 'loose'
+});
+
+// Helper functions
+function resolveOption<T>(opt: any, defaultValue: T): T {
+  return opt != null ? opt as T : defaultValue;
+}
+
+function getAllProcesses(ldGraph: LDGraph, context: LDContext): LDNode[] {
+  return ldGraph.Nodes.filter(
+    node => ROCrate.LDLabProcess.validate(node, context)
+  );
+}
+
+function extractNodeMetadata(node: LDNode, ldGraph: LDGraph, context: LDContext): Record<string, string> {
+  const metadata: Record<string, string> = {};
+
+  try {
+    if (node.SchemaType && node.SchemaType[0] === "Sample") {
+      const props = ROCrate.LDSample.getAdditionalProperties(node, ldGraph, context);
+      props.forEach((s) => {
+        const name = ROCrate.LDPropertyValue.getNameAsString(s, context);
+        const value = resolveOption(ROCrate.LDPropertyValue.tryGetValueAsString(s, context), "");
+        metadata[name] = value;
+      });
+    } else if (node.SchemaType && node.SchemaType[0] === "LabProcess") {
+      const params = ROCrate.LDLabProcess.getParameterValues(node, ldGraph, context);
+      params.forEach((s) => {
+        const name = ROCrate.LDPropertyValue.getNameAsString(s, context);
+        const value = resolveOption(ROCrate.LDPropertyValue.tryGetValueAsString(s, context), "");
+        metadata[name] = value;
+      });
+    }
+  } catch (error) {
+    console.error("Error extracting node metadata:", node, error);
+  }
+
+  return metadata;
+}
+
+function filterToSubgraph(graph: ProvenanceGraph, targetNodeId: string): ProvenanceGraph {
+  const reachableNodes = new Set<string>();
+  const reachableEdges: ProvenanceEdge[] = [];
+
+  // BFS backwards from target to find all nodes that lead to it
+  const queue = [targetNodeId];
+  reachableNodes.add(targetNodeId);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+
+    // Find all edges that have current as target
+    const incomingEdges = graph.edges.filter(e => e.to === current);
+
+    incomingEdges.forEach(edge => {
+      reachableEdges.push(edge);
+      if (!reachableNodes.has(edge.from)) {
+        reachableNodes.add(edge.from);
+        queue.push(edge.from);
+      }
+    });
+  }
+
+  // Filter nodes to only those that are reachable
+  const filteredNodes = graph.nodes.filter(node => reachableNodes.has(node.id));
+
+  return {
+    nodes: filteredNodes,
+    edges: reachableEdges,
+  };
+}
+
+function extractProvenance(ldGraph: LDGraph): ProvenanceGraph | null {
+  try {
+    const context = ldGraph.TryGetContext();
+
+    if (!context) {
+      console.error("No context found in LDGraph");
+      return null;
+    }
+
+    const nodes: ProvenanceNode[] = [];
+    const edges: ProvenanceEdge[] = [];
+    const nodeMap: Record<string, ProvenanceNode> = {};
+
+    const processes = getAllProcesses(ldGraph, context as LDContext);
+
+    processes.forEach((process) => {
+      const inputs = ROCrate.LDLabProcess.getObjects(process, ldGraph, context as LDContext);
+      const outputs = ROCrate.LDLabProcess.getResults(process, ldGraph, context as LDContext);
+
+      if (inputs.length > 0 && outputs.length > 0) {
+        const input = inputs[0];
+        const output = outputs[0];
+
+        // Add input node if not exists
+        if (!nodeMap[input.id]) {
+          const inputNode: ProvenanceNode = {
+            id: input.id,
+            label: input.id,
+            type: input.AdditionalType?.[0] || input.SchemaType?.[0] || "Unknown",
+            metadata: extractNodeMetadata(input, ldGraph, context as LDContext),
+          };
+          nodeMap[input.id] = inputNode;
+          nodes.push(inputNode);
+        }
+
+        // Add output node if not exists
+        if (!nodeMap[output.id]) {
+          const outputNode: ProvenanceNode = {
+            id: output.id,
+            label: output.id,
+            type: output.AdditionalType?.[0] || output.SchemaType?.[0] || "Unknown",
+            metadata: extractNodeMetadata(output, ldGraph, context as LDContext),
+          };
+          nodeMap[output.id] = outputNode;
+          nodes.push(outputNode);
+        }
+
+        // Add edge
+        let processLabel = process.id;
+        const protocol = ROCrate.LDLabProcess.tryGetExecutesLabProtocol(process, ldGraph, context as LDContext);
+        if (protocol) {
+          processLabel = resolveOption(
+            ROCrate.LDLabProtocol.tryGetNameAsString(protocol as LDNode, context as LDContext),
+            (protocol as LDNode).id
+          );
+        }
+
+        edges.push({
+          from: input.id,
+          to: output.id,
+          label: processLabel,
+          metadata: extractNodeMetadata(process, ldGraph, context as LDContext),
+        });
+      }
+    });
+
+    return { nodes, edges };
+  } catch (error) {
+    console.error("Error extracting provenance:", error);
+    return null;
+  }
+}
+
+function getNodeColor(type: string): string {
+  if (type.includes("Sample")) return "#8957e5";
+  if (type.includes("LabProcess")) return "#1f6feb";
+  if (type.includes("File")) return "#238636";
+  if (type.includes("Source")) return "#d29922";
+  return "#424242";
+}
+
+function generateMermaidDiagram(graph: ProvenanceGraph): string {
+  const nodes = graph.nodes.map((node) => {
+    const safeId = node.id.replace(/[^\w-]/g, '_');
+    const typeClass = node.type.replace(/\s+/g, '_').toLowerCase();
+    const cleanLabel = node.label.replace(/^#(Source_|Sample_)/, '');
+    return `${safeId}["${cleanLabel}<br/><sub>${node.type}</sub>"]:::${typeClass}`;
+  }).join('\n    ');
+
+  const edges = graph.edges.map((edge) => {
+    const fromId = edge.from.replace(/[^\w-]/g, '_');
+    const toId = edge.to.replace(/[^\w-]/g, '_');
+    return `${fromId} -->|${edge.label}| ${toId}`;
+  }).join('\n    ');
+
+  const classDefinitions = `
+    classDef sample fill:#8957e5,stroke:#6f42c1,stroke-width:2px,color:#fff,font-size:12px,padding:8px
+    classDef labprocess fill:#1f6feb,stroke:#0969da,stroke-width:2px,color:#fff,font-size:12px,padding:8px
+    classDef file fill:#238636,stroke:#1a7f0e,stroke-width:2px,color:#fff,font-size:12px,padding:8px
+    classDef source fill:#d29922,stroke:#b8860b,stroke-width:2px,color:#000,font-size:12px,padding:8px
+    classDef unknown fill:#424242,stroke:#222,stroke-width:2px,color:#fff,font-size:12px,padding:8px`;
+
+  return `flowchart TD
+    ${nodes}
+    ${edges}
+    ${classDefinitions}`;
+}
+
+interface FileProvenanceViewerProps {
+  fileNode?: TreeNode;
+  onClose?: () => void;
+  ldGraph?: LDGraph;
+}
+
+export default function FileProvenanceViewer({
+  fileNode,
+  onClose,
+  ldGraph
+}: FileProvenanceViewerProps) {
+  const fileName = fileNode?.name || 'output.fastq';
+  const [activeTab, setActiveTab] = useState<'diagram' | 'details'>('diagram');
+  const [svgContent, setSvgContent] = useState<string>('');
+  const [provenance, setProvenance] = useState<ProvenanceGraph | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const mermaidRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ldGraph) {
+      setError("No ARC data provided");
+      return;
+    }
+
+    const extracted = extractProvenance(ldGraph);
+    if (!extracted) {
+      setError("Failed to extract provenance from ARC data");
+      return;
+    }
+
+    // Look for target node by exact id match
+    const targetNode = extracted.nodes.find(node => node.id === fileNode?.id);
+
+    if (!targetNode) {
+      setError(`No provenance data available for this file`);
+      setProvenance(null);
+      return;
+    }
+
+    // Filter to subgraph leading to target
+    const filteredProvenance = filterToSubgraph(extracted, targetNode.id);
+    setProvenance(filteredProvenance);
+    setError(null);
+  }, [ldGraph, fileNode?.id]);
+
+  useEffect(() => {
+    if (!provenance) return;
+
+    const renderDiagram = async () => {
+      try {
+        const mermaidCode = generateMermaidDiagram(provenance);
+        const { svg } = await mermaid.render('provenance-diagram', mermaidCode);
+        setSvgContent(svg);
+      } catch (error) {
+        console.error('Error rendering Mermaid diagram:', error);
+        setError("Failed to render diagram");
+      }
+    };
+    renderDiagram();
+  }, [provenance]);
+
+  if (error || !provenance) {
+    return (
+      <div
+        style={{
+          backgroundColor: 'white',
+          borderRadius: '8px',
+          boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+          maxWidth: '1000px',
+          maxHeight: '90vh',
+          padding: '24px',
+          textAlign: 'center',
+        }}
+      >
+        <h2 style={{ margin: '0 0 12px 0' }}>No Provenance Available</h2>
+        <p style={{ margin: 0, color: '#666' }}>
+          {error || "Could not load provenance data for this file."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        backgroundColor: 'white',
+        borderRadius: '8px',
+        boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+        maxWidth: '1000px',
+        maxHeight: '90vh',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div style={{ padding: '12px 16px', borderBottom: '1px solid #e1e4e8', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <h2 style={{ margin: '0 0 2px 0', fontSize: '1.3em' }}>File Provenance</h2>
+          <p style={{ margin: 0, fontSize: '0.85em', color: '#666' }}>{fileName}</p>
+        </div>
+        {onClose && (
+          <button
+            onClick={onClose}
+            style={{
+              background: 'none',
+              border: 'none',
+              fontSize: '1.5em',
+              cursor: 'pointer',
+              color: '#666',
+              padding: '0',
+              width: '32px',
+              height: '32px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', borderBottom: '1px solid #e1e4e8' }}>
+        <button
+          onClick={() => setActiveTab('diagram')}
+          style={{
+            background: 'none',
+            border: 'none',
+            padding: '8px 16px',
+            cursor: 'pointer',
+            fontSize: '0.95em',
+            fontWeight: activeTab === 'diagram' ? '600' : '400',
+            color: activeTab === 'diagram' ? '#0969da' : '#666',
+            borderBottom: activeTab === 'diagram' ? '2px solid #0969da' : 'none',
+            marginBottom: '-1px',
+          }}
+        >
+          Provenance
+        </button>
+        <button
+          onClick={() => setActiveTab('details')}
+          style={{
+            background: 'none',
+            border: 'none',
+            padding: '8px 16px',
+            cursor: 'pointer',
+            fontSize: '0.95em',
+            fontWeight: activeTab === 'details' ? '600' : '400',
+            color: activeTab === 'details' ? '#0969da' : '#666',
+            borderBottom: activeTab === 'details' ? '2px solid #0969da' : 'none',
+            marginBottom: '-1px',
+          }}
+        >
+          Details
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '16px', display: activeTab === 'diagram' ? 'block' : 'none' }}>
+        <div
+          ref={mermaidRef}
+          dangerouslySetInnerHTML={{ __html: svgContent }}
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'flex-start',
+            width: '100%',
+          }}
+        />
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '12px', display: activeTab === 'details' ? 'block' : 'none', fontSize: '0.9em' }}>
+        <div>
+          <h3 style={{ margin: '0 0 8px 0', fontSize: '1em', borderBottom: '2px solid #e1e4e8', paddingBottom: '4px' }}>Nodes</h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {provenance.nodes.map((node) => {
+              const metadataColumns: Column<UniqueRow>[] = ['Property', 'Value'].map((header) => ({
+                header,
+                field: header as any,
+              }));
+
+              const metadataRows = node.metadata
+                ? Object.entries(node.metadata).map(([key, value], idx) => ({
+                    id: String(idx),
+                    Property: key,
+                    Value: value,
+                  }))
+                : [];
+
+              return (
+                <div key={node.id} style={{ padding: '8px', backgroundColor: '#f6f8fa', borderRadius: '4px', border: `1px solid ${getNodeColor(node.type)}33` }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px' }}>
+                    <div
+                      style={{
+                        width: '10px',
+                        height: '10px',
+                        borderRadius: '50%',
+                        backgroundColor: getNodeColor(node.type),
+                      }}
+                    />
+                    <span style={{ fontWeight: '600' }}>{node.label}</span>
+                    <span style={{ fontSize: '0.8em', color: '#666', backgroundColor: '#e8eef2', padding: '1px 4px', borderRadius: '3px' }}>
+                      {node.type}
+                    </span>
+                  </div>
+                  {metadataRows.length > 0 && (
+                    <Table.Container>
+                      <DataTable
+                        data={metadataRows}
+                        columns={metadataColumns}
+                        cellPadding="condensed"
+                      />
+                    </Table.Container>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div style={{ marginTop: '16px' }}>
+          <h3 style={{ margin: '0 0 8px 0', fontSize: '1em', borderBottom: '2px solid #e1e4e8', paddingBottom: '4px' }}>Transformations</h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {provenance.edges.map((edge, idx) => {
+              const fromNode = provenance.nodes.find((n) => n.id === edge.from);
+              const toNode = provenance.nodes.find((n) => n.id === edge.to);
+
+              const metadataColumns: Column<UniqueRow>[] = ['Property', 'Value'].map((header) => ({
+                header,
+                field: header as any,
+              }));
+
+              const metadataRows = edge.metadata
+                ? Object.entries(edge.metadata).map(([key, value], i) => ({
+                    id: String(i),
+                    Property: key,
+                    Value: value,
+                  }))
+                : [];
+
+              return (
+                <div key={idx} style={{ padding: '8px', backgroundColor: '#f6f8fa', borderRadius: '4px', border: '1px solid #ddf4ff' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px', fontSize: '0.9em' }}>
+                    <span style={{ fontWeight: '600' }}>{fromNode?.label}</span>
+                    <span style={{ color: '#666' }}>→</span>
+                    <span style={{ fontWeight: '600' }}>{toNode?.label}</span>
+                  </div>
+                  {edge.label && (
+                    <div style={{ marginBottom: '8px', padding: '4px 6px', backgroundColor: '#ddf4ff', color: '#0969da', borderRadius: '3px', fontSize: '0.85em', fontWeight: '600' }}>
+                      {edge.label}
+                    </div>
+                  )}
+                  {metadataRows.length > 0 && (
+                    <Table.Container>
+                      <DataTable
+                        data={metadataRows}
+                        columns={metadataColumns}
+                        cellPadding="condensed"
+                      />
+                    </Table.Container>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -187,20 +187,33 @@ function escapeMermaidLabel(text: string): string {
     .replace(/[\r\n]+/g, ' ');
 }
 
+// Builds a Mermaid `flowchart TD` source string from our provenance graph.
 function generateMermaidDiagram(graph: ProvenanceGraph): string {
   const nodes = graph.nodes.map((node) => {
+    // ROCrate ids like "#Sample_DB40" aren't valid Mermaid node ids — strip
+    // anything that isn't a word char or hyphen.
     const safeId = node.id.replace(/[^\w-]/g, '_');
+    // Same constraint applies to classDef class names.
     const typeClass = node.type.replace(/[^\w-]/g, '_').toLowerCase() || 'unknown';
+    // Drop the ROCrate id prefix from the visible label so nodes show e.g.
+    // "DB40" instead of "#Sample_DB40".
     const cleanLabel = node.label.replace(/^#(Source_|Sample_)/, '');
+    // <br/> and <sub> are part of Mermaid's own label vocabulary and survive
+    // securityLevel: 'strict'; user-supplied substrings get HTML-entity-encoded
+    // by escapeMermaidLabel so they can't break out of the "..." or inject tags.
     return `${safeId}["${escapeMermaidLabel(cleanLabel)}<br/><sub>${escapeMermaidLabel(node.type)}</sub>"]:::${typeClass}`;
   }).join('\n    ');
 
   const edges = graph.edges.map((edge) => {
     const fromId = edge.from.replace(/[^\w-]/g, '_');
     const toId = edge.to.replace(/[^\w-]/g, '_');
+    // Quoted edge label (`|"..."|`) is the Mermaid form that tolerates escaped
+    // special chars inside the label.
     return `${fromId} -->|"${escapeMermaidLabel(edge.label)}"| ${toId}`;
   }).join('\n    ');
 
+  // One classDef per node type we recognize, plus a fallback. The class suffix
+  // `:::typeClass` on each node above picks one of these.
   const classDefinitions = `
     classDef sample fill:#8957e5,stroke:#6f42c1,stroke-width:2px,color:#fff,font-size:12px,padding:8px
     classDef labprocess fill:#1f6feb,stroke:#0969da,stroke-width:2px,color:#fff,font-size:12px,padding:8px

--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import mermaid from 'mermaid';
+import mermaid from '../../util/mermaid';
 import { Table, DataTable, type UniqueRow, type Column } from '@primer/react/experimental';
 import { JsonController, ROCrate } from '@nfdi4plants/arctrl';
 import type { TreeNode } from '../../util/types';
@@ -27,17 +27,6 @@ interface ProvenanceGraph {
 type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
 type LDContext = Parameters<typeof ROCrate.LDLabProcess.validate>[1];
 type LDNode = Parameters<typeof ROCrate.LDLabProcess.validate>[0];
-
-mermaid.initialize({
-  startOnLoad: false,
-  theme: 'default',
-  flowchart: {
-    padding: 10,
-    nodeSpacing: 30,
-    rankSpacing: 40,
-  },
-  securityLevel: 'loose'
-});
 
 // Helper functions
 function resolveOption<T>(opt: any, defaultValue: T): T {

--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -66,30 +66,34 @@ function extractNodeMetadata(node: LDNode, ldGraph: LDGraph, context: LDContext)
 }
 
 function filterToSubgraph(graph: ProvenanceGraph, targetNodeId: string): ProvenanceGraph {
-  const reachableNodes = new Set<string>();
+  // Precompute incoming edges by target id so the traversal is linear in the
+  // reachable subgraph instead of O(V*E).
+  const incomingByTo = new Map<string, ProvenanceEdge[]>();
+  graph.edges.forEach((edge) => {
+    const list = incomingByTo.get(edge.to);
+    if (list) list.push(edge);
+    else incomingByTo.set(edge.to, [edge]);
+  });
+
+  const reachableNodes = new Set<string>([targetNodeId]);
   const reachableEdges: ProvenanceEdge[] = [];
+  const stack = [targetNodeId];
 
-  // BFS backwards from target to find all nodes that lead to it
-  const queue = [targetNodeId];
-  reachableNodes.add(targetNodeId);
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const incomingEdges = incomingByTo.get(current);
+    if (!incomingEdges) continue;
 
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-
-    // Find all edges that have current as target
-    const incomingEdges = graph.edges.filter(e => e.to === current);
-
-    incomingEdges.forEach(edge => {
+    incomingEdges.forEach((edge) => {
       reachableEdges.push(edge);
       if (!reachableNodes.has(edge.from)) {
         reachableNodes.add(edge.from);
-        queue.push(edge.from);
+        stack.push(edge.from);
       }
     });
   }
 
-  // Filter nodes to only those that are reachable
-  const filteredNodes = graph.nodes.filter(node => reachableNodes.has(node.id));
+  const filteredNodes = graph.nodes.filter((node) => reachableNodes.has(node.id));
 
   return {
     nodes: filteredNodes,

--- a/src/components/FileProvenanceViewer/index.tsx
+++ b/src/components/FileProvenanceViewer/index.tsx
@@ -178,18 +178,28 @@ function getNodeColor(type: string): string {
   return "#424242";
 }
 
+function escapeMermaidLabel(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\|/g, '&#124;')
+    .replace(/[\r\n]+/g, ' ');
+}
+
 function generateMermaidDiagram(graph: ProvenanceGraph): string {
   const nodes = graph.nodes.map((node) => {
     const safeId = node.id.replace(/[^\w-]/g, '_');
-    const typeClass = node.type.replace(/\s+/g, '_').toLowerCase();
+    const typeClass = node.type.replace(/[^\w-]/g, '_').toLowerCase() || 'unknown';
     const cleanLabel = node.label.replace(/^#(Source_|Sample_)/, '');
-    return `${safeId}["${cleanLabel}<br/><sub>${node.type}</sub>"]:::${typeClass}`;
+    return `${safeId}["${escapeMermaidLabel(cleanLabel)}<br/><sub>${escapeMermaidLabel(node.type)}</sub>"]:::${typeClass}`;
   }).join('\n    ');
 
   const edges = graph.edges.map((edge) => {
     const fromId = edge.from.replace(/[^\w-]/g, '_');
     const toId = edge.to.replace(/[^\w-]/g, '_');
-    return `${fromId} -->|${edge.label}| ${toId}`;
+    return `${fromId} -->|"${escapeMermaidLabel(edge.label)}"| ${toId}`;
   }).join('\n    ');
 
   const classDefinitions = `

--- a/src/components/FileTable/index.tsx
+++ b/src/components/FileTable/index.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
-import {IconButton, Link, Truncate, useResponsiveValue } from '@primer/react'
+import { lazy, Suspense, useState } from 'react'
+import {IconButton, Link, Spinner, Truncate, useResponsiveValue } from '@primer/react'
 import {Table, DataTable, Dialog} from '@primer/react/experimental'
 import { JsonController } from '@nfdi4plants/arctrl'
 import { type TreeNode } from '../../util/types'
 import Icons from '../Icons'
-import FileProvenanceViewer from '../FileProvenanceViewer'
+
+const FileProvenanceViewer = lazy(() => import('../FileProvenanceViewer'))
 
 type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
 
@@ -213,10 +214,12 @@ export default function FileTable({ loading, currentTreeNode, navigateTo, ldGrap
           width="xlarge"
           height="large"
         >
-          <FileProvenanceViewer
-            fileNode={selectedFileForProvenance}
-            ldGraph={ldGraph}
-          />
+          <Suspense fallback={<div style={{ padding: '24px', textAlign: 'center' }}><Spinner /></div>}>
+            <FileProvenanceViewer
+              fileNode={selectedFileForProvenance}
+              ldGraph={ldGraph}
+            />
+          </Suspense>
         </Dialog>
       )}
     </>

--- a/src/components/FileTable/index.tsx
+++ b/src/components/FileTable/index.tsx
@@ -1,7 +1,12 @@
+import { useState } from 'react'
 import {IconButton, Link, Truncate, useResponsiveValue } from '@primer/react'
 import {Table, DataTable} from '@primer/react/experimental'
+import { JsonController } from '@nfdi4plants/arctrl'
 import { type TreeNode } from '../../util/types'
 import Icons from '../Icons'
+import FileProvenanceViewer from '../FileProvenanceViewer'
+
+type LDGraph = ReturnType<typeof JsonController.LDGraph.fromROCrateJsonString>;
 
 
 function sortTreeNode(node: TreeNode | undefined): TreeNode[] {
@@ -17,9 +22,10 @@ function sortTreeNode(node: TreeNode | undefined): TreeNode[] {
 interface HeaderProps {
   navigateTo: (path: string) => void;
   responsiveValue: "narrow" | "regular" | "wide"
+  onShowProvenance?: (file: TreeNode) => void;
 }
 
-const mkHeader = ({navigateTo, responsiveValue}: HeaderProps) => {
+const mkHeader = ({navigateTo, responsiveValue, onShowProvenance}: HeaderProps) => {
     return [
       {
         id: 'icon',
@@ -88,12 +94,40 @@ const mkHeader = ({navigateTo, responsiveValue}: HeaderProps) => {
         header: "File Size",
         renderCell: (row: TreeNode) => {
           return (
-            row.contentSize 
+            row.contentSize
               ? <div style={{width: "content-min"}}>
                 <Truncate title={row.contentSize} maxWidth="200px">{row.contentSize}</Truncate >
               </div>
               : null
           )
+        },
+      },
+      {
+        id: 'provenance',
+        width: 'auto',
+        minWidth: '50px',
+        align: 'end',
+        header: 'Provenance',
+        renderCell: (row: TreeNode) => {
+          return row.sha256 ? (
+            <button
+              aria-label={`Show provenance: ${row.name}`}
+              title={`Show provenance: ${row.name}`}
+              onClick={() => onShowProvenance?.(row)}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '4px',
+                fontSize: '1.2em',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              🔗
+            </button>
+          ) : null;
         },
       },
       {
@@ -104,7 +138,7 @@ const mkHeader = ({navigateTo, responsiveValue}: HeaderProps) => {
         header: 'Download',
         renderCell: (row: TreeNode) => {
           return (
-            row.sha256 
+            row.sha256
               ? <IconButton
                 as="a"
                 href={`https://lfs-resolver.nfdi4plants.org/presigned-url/?oid=${row.sha256}`}
@@ -125,25 +159,34 @@ interface FileTableProps {
   loading: boolean;
   currentTreeNode: TreeNode | undefined;
   navigateTo: (path: string) => void;
+  ldGraph?: LDGraph;
 }
 
-export default function FileTable({ loading, currentTreeNode, navigateTo }: FileTableProps) {
+export default function FileTable({ loading, currentTreeNode, navigateTo, ldGraph }: FileTableProps) {
+  const [showProvenance, setShowProvenance] = useState(false);
+  const [selectedFileForProvenance, setSelectedFileForProvenance] = useState<TreeNode | undefined>();
+
+  const handleShowProvenance = (file: TreeNode) => {
+    setSelectedFileForProvenance(file);
+    setShowProvenance(true);
+  };
 
   const headerVal = useResponsiveValue(
     {
-      narrow: mkHeader({ navigateTo, responsiveValue: 'narrow' }),
-      regular: mkHeader({ navigateTo, responsiveValue: 'regular' }),
-      wide: mkHeader({ navigateTo, responsiveValue: 'wide' }),
-    }, 
-    mkHeader({ navigateTo, responsiveValue: 'regular' })
+      narrow: mkHeader({ navigateTo, responsiveValue: 'narrow', onShowProvenance: handleShowProvenance }),
+      regular: mkHeader({ navigateTo, responsiveValue: 'regular', onShowProvenance: handleShowProvenance }),
+      wide: mkHeader({ navigateTo, responsiveValue: 'wide', onShowProvenance: handleShowProvenance }),
+    },
+    mkHeader({ navigateTo, responsiveValue: 'regular', onShowProvenance: handleShowProvenance })
   )
 
   return (
+    <>
       <Table.Container>
         {/* <Table.Actions>
           <Button>Action</Button>
         </Table.Actions> */}
-        { loading 
+        { loading
           ? <Table.Skeleton
             aria-labelledby="repositories-loading"
             cellPadding="condensed"
@@ -161,5 +204,36 @@ export default function FileTable({ loading, currentTreeNode, navigateTo }: File
           />
         }
       </Table.Container>
+
+      {showProvenance && selectedFileForProvenance && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 9999,
+            padding: '20px',
+          }}
+          onClick={() => setShowProvenance(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{ width: '100%', maxWidth: '900px' }}
+          >
+            <FileProvenanceViewer
+              fileNode={selectedFileForProvenance}
+              onClose={() => setShowProvenance(false)}
+              ldGraph={ldGraph}
+            />
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/src/components/FileTable/index.tsx
+++ b/src/components/FileTable/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import {IconButton, Link, Truncate, useResponsiveValue } from '@primer/react'
-import {Table, DataTable} from '@primer/react/experimental'
+import {Table, DataTable, Dialog} from '@primer/react/experimental'
 import { JsonController } from '@nfdi4plants/arctrl'
 import { type TreeNode } from '../../util/types'
 import Icons from '../Icons'
@@ -206,33 +206,18 @@ export default function FileTable({ loading, currentTreeNode, navigateTo, ldGrap
       </Table.Container>
 
       {showProvenance && selectedFileForProvenance && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 9999,
-            padding: '20px',
-          }}
-          onClick={() => setShowProvenance(false)}
+        <Dialog
+          title="File Provenance"
+          subtitle={selectedFileForProvenance.name}
+          onClose={() => setShowProvenance(false)}
+          width="xlarge"
+          height="large"
         >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            style={{ width: '100%', maxWidth: '900px' }}
-          >
-            <FileProvenanceViewer
-              fileNode={selectedFileForProvenance}
-              onClose={() => setShowProvenance(false)}
-              ldGraph={ldGraph}
-            />
-          </div>
-        </div>
+          <FileProvenanceViewer
+            fileNode={selectedFileForProvenance}
+            ldGraph={ldGraph}
+          />
+        </Dialog>
       )}
     </>
   )

--- a/src/components/MarkdownRender/index.tsx
+++ b/src/components/MarkdownRender/index.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useLayoutEffect, useState } from 'react';
 import { marked } from 'marked';
-import mermaid from 'mermaid';
+import mermaid from '../../util/mermaid';
 import {SkeletonText} from '@primer/react/experimental'
 
 interface MarkdownRenderProps {
   // must be markdown string
   content: string;
 }
-
-mermaid.initialize({startOnLoad: false})
 
 export default function MarkdownRender({content}: MarkdownRenderProps) { 
 

--- a/src/components/WebViewer/index.tsx
+++ b/src/components/WebViewer/index.tsx
@@ -800,6 +800,7 @@ export default function WebViewer({
                             loading={arc.loading}
                             currentTreeNode={currentTreeNode}
                             navigateTo={navigateTo}
+                            ldGraph={ldGraph.value}
                         />
                     )}
                     {tree.value &&

--- a/src/util/mermaid.ts
+++ b/src/util/mermaid.ts
@@ -1,0 +1,14 @@
+import mermaid from 'mermaid';
+
+mermaid.initialize({
+  startOnLoad: false,
+  theme: 'default',
+  flowchart: {
+    padding: 10,
+    nodeSpacing: 30,
+    rankSpacing: 40,
+  },
+  securityLevel: 'loose',
+});
+
+export default mermaid;

--- a/src/util/mermaid.ts
+++ b/src/util/mermaid.ts
@@ -8,7 +8,7 @@ mermaid.initialize({
     nodeSpacing: 30,
     rankSpacing: 40,
   },
-  securityLevel: 'loose',
+  securityLevel: 'strict',
 });
 
 export default mermaid;


### PR DESCRIPTION
This is a basic implementation of an idea by @muehlhaus using mermaid (since that's already installed in the project anyway): being able to see the provenance of a specific data file (i.e. the subgraph leading up to that data file). It's not very pretty but it works, let me know if you have ideas for improvement!

<img width="1071" height="406" alt="Screenshot 2026-03-24 at 14 14 18" src="https://github.com/user-attachments/assets/cb6b34ca-a8ae-475d-90b2-9f2c5350f6e1" />

<img width="890" height="698" alt="Screenshot 2026-03-24 at 14 13 42" src="https://github.com/user-attachments/assets/3c8e1aa7-f452-4bdf-8b21-66e4d9de3db4" />

<img width="884" height="689" alt="Screenshot 2026-03-24 at 14 14 00" src="https://github.com/user-attachments/assets/1eca1ddb-f318-48d7-ab84-eb8c08414569" />

A more complex case:
<img width="897" height="287" alt="Screenshot 2026-03-24 at 14 15 13" src="https://github.com/user-attachments/assets/daab3ecb-210a-40b4-b703-b708ef73f12f" />
